### PR TITLE
Add missing `lstrip` in `INPUT_CLASSIFICATION_TEMPLATE`

### DIFF
--- a/distilabel_pipelines/magpie_ultra_v1/pipeline.py
+++ b/distilabel_pipelines/magpie_ultra_v1/pipeline.py
@@ -342,7 +342,7 @@ Now, please output your tags below in a json format by filling in the placeholde
     "other_tags": ["<tag 1>", "<tag 2>", ... ]
 }}
 ```
-"""
+""".lstrip()
 
 
 OUTPUT_CLASSIFICATION_JSON_SCHEMA = {


### PR DESCRIPTION
## Description

This PR adds a missing `lstrip` (assuming that was not intended) within the `INPUT_CLASSIFICATION_TEMPLATE` of the `distilabel` pipeline for Magpie Ultra v0.1.

cc @gabrielmbmb 