### PR TITLE
Update train.py for recent trl

### DIFF
--- a/text/finetuning/requirements.txt
+++ b/text/finetuning/requirements.txt
@@ -1,5 +1,5 @@
 transformers
-trl
+trl>=0.15
 peft
 accelerate
 datasets

--- a/text/finetuning/train.py
+++ b/text/finetuning/train.py
@@ -28,6 +28,7 @@ def get_args():
     parser.add_argument("--dataset_name", type=str, default="bigcode/the-stack-smol")
     parser.add_argument("--subset", type=str, default="data/python")
     parser.add_argument("--split", type=str, default="train")
+    parser.add_argument("--streaming", type=bool, default=False)
     parser.add_argument("--dataset_text_field", type=str, default="content")
 
     parser.add_argument("--max_seq_length", type=int, default=2048)
@@ -83,7 +84,8 @@ def main(args):
         data_dir=args.subset,
         split=args.split,
         token=token,
-        num_proc=args.num_proc if args.num_proc else multiprocessing.cpu_count(),
+        num_proc=args.num_proc if args.num_proc or args.streaming else multiprocessing.cpu_count(),
+        streaming=args.streaming,
     )
 
     # setup the trainer

--- a/text/finetuning/train.py
+++ b/text/finetuning/train.py
@@ -94,6 +94,7 @@ def main(args):
         train_dataset=data,
         args=SFTConfig(
             dataset_text_field=args.dataset_text_field,
+            dataset_num_proc=args.num_proc,
             max_seq_length=args.max_seq_length,
             per_device_train_batch_size=args.micro_batch_size,
             gradient_accumulation_steps=args.gradient_accumulation_steps,

--- a/text/finetuning/train.py
+++ b/text/finetuning/train.py
@@ -132,7 +132,7 @@ def main(args):
         else:
             torch.cuda.empty_cache()
 
-        model = AutoPeftModelForCausalLM.from_pretrained(args.output_dir, device_map="auto", torch_dtype=torch.bfloat16)
+        model = AutoPeftModelForCausalLM.from_pretrained(os.path.join(args.output_dir, "final_checkpoint/"), device_map="auto", torch_dtype=torch.bfloat16)
         model = model.merge_and_unload()
 
         output_merged_dir = os.path.join(args.output_dir, "final_merged_checkpoint")

--- a/text/finetuning/train.py
+++ b/text/finetuning/train.py
@@ -111,7 +111,7 @@ def main(args):
             run_name=f"train-{args.model_id.split('/')[-1]}",
             report_to="wandb",
             push_to_hub=args.push_to_hub,
-            push_to_hub_model_id=args.repo_id,
+            hub_model_id=args.repo_id,
         ),
         peft_config=lora_config,
     )


### PR DESCRIPTION
support trl>=0.15 - now most training args are in SFTConfig

cc @loubnabnl 

I might use this script to demo HF jobs, but lmk if you have better scripts ideas

TODO: fix one last bug on push_to_hub:

```
ValueError: Can't find 'adapter_config.json' at 'finetune_smollm2_python/final_checkpoint/'
```

is it because now trl saves the model already merged ? cc @qgallouedec