### PR TITLE
Pin num2words

### DIFF
--- a/vision/smolvlm2/pyproject.toml
+++ b/vision/smolvlm2/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "decord",
   "liger-kernel",
   "tabulate",
-  "num2words",
+  "num2words==0.5.14",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Pin `num2words` to avoid supply-chain attack: https://www.stepsecurity.io/blog/supply-chain-security-alert-num2words-pypi-package-shows-signs-of-compromise